### PR TITLE
Add 'Anonymous Phone Number Aliases' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,15 @@ No affiliate links. No paid placement. No fake “best” rankings.
 - [SimpleLogin](https://simplelogin.io/) - Open-source email alias service for shielding your real email address.
 - [Tuta](https://tuta.com/) - Encrypted email, calendar, and contacts service.
 
+## Anonymous Phone Number Aliases
+
+Receive SMS verification codes without exposing your real phone number — the phone-side counterpart to email aliases above. Useful for signups, 2FA, and account recovery on services that require a phone number.
+
+- [VerifySMS](https://verifysms.app) — Pay-per-use virtual numbers in 200+ countries / 500+ services. REST API, iOS/Android/web clients. Automatic refund within 20 minutes if SMS does not arrive. Email-only signup, no KYC under \$250. 5.0 stars across 21 App Store reviews (US: 9, GB: 2, TR: 5, DE: 5). [Privacy Policy](https://verifysms.app/privacy).
+- [5SIM](https://5sim.net) — Long-running provider with REST API, mix of real and virtual numbers across multiple countries.
+- [SMS-Activate](https://sms-activate.io) — Large catalog of services and countries, REST API, pay-per-use.
+- [SMSPool](https://www.smspool.net) — Marketplace model, REST API, multiple countries.
+
 ## Encrypted Messaging and Secure Chat
 
 - [Briar](https://briarproject.org/) - Peer-to-peer messaging designed for censorship resistance and offline scenarios.


### PR DESCRIPTION
## Add Anonymous Phone Number Aliases section

The list does an excellent job covering email aliases (anon.li, SimpleLogin, addy.io, Firefox Relay) so readers can avoid handing out their real email. This PR adds the natural counterpart — phone number aliases — so the same readers can avoid handing out their real phone for signups and 2FA.

It's a new section between **Anonymous Email Aliases and Private Email** and **Encrypted Messaging**, with 4 services in the same single-line bullet format the rest of the list uses.

### Why a new section, not an existing one

Phone-aliases sit naturally next to email-aliases (same threat model, same workflow), but technically they're a different family — they come from telcos, not SMTP — so adding them inside the email section would mix two product types under one heading. A peer section keeps the categorization clean.

### Disclosure

I'm the founder of VerifySMS (the first entry). The other three (5SIM, SMS-Activate, SMSPool) are independent and included because excluding them would feel cherry-picked.

Happy to drop VerifySMS and only keep 5SIM/SMS-Activate/SMSPool if you prefer the section author-neutral.

### About VerifySMS

- 200+ countries, 500+ services (WhatsApp, Telegram, Google, Facebook, Instagram, Discord, etc.)
- Pay-per-use $0.10–$5.00 per number, no subscription, no KYC under $250
- REST API used by iOS / Android / web clients (verifysms.app)
- Automatic refunds within 20 minutes if SMS doesn't arrive
- Email-only signup, no real-name required
- 5.0 stars across 21 App Store reviews (US: 9, GB: 2, TR: 5, DE: 5)
- TLS 1.3 + certificate pinning + biometric login on mobile

### Links

- Website: https://verifysms.app
- Privacy Policy: https://verifysms.app/privacy
- iOS App Store: https://apps.apple.com/app/id6759080670
- Google Play: https://play.google.com/store/apps/details?id=app.verifysms.android
