### PR TITLE
Add A/SIDE to Encrypted Messaging and Secure Chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Receive SMS verification codes without exposing your real phone number — the p
 
 ## Encrypted Messaging and Secure Chat
 
+- [A/SIDE](https://a-side.social) — Invitation-only private social network with end-to-end encryption using the Signal Protocol. No algorithmic feed, no ads, and no AI training on user content.
 - [Briar](https://briarproject.org/) - Peer-to-peer messaging designed for censorship resistance and offline scenarios.
 - [Element](https://element.io/) - Matrix client for end-to-end encrypted personal and team chat.
 - [Jami](https://jami.net/) - Peer-to-peer voice, video, and messaging app.


### PR DESCRIPTION
Adding A/SIDE (https://a-side.social) to the Encrypted Messaging and Secure Chat section.

A/SIDE is a private social network for close friends and small groups. End-to-end encrypted with the Signal Protocol. Invitation-only with mutual consent required. Strictly chronological feed — no algorithm, no ads, no AI training on user content. iOS and Android.

Disclosure: I am the developer. A/SIDE is a shipped, publicly available app on the iOS App Store and Google Play Store.