### PR TITLE
Add UltraLocked to File Encryption and Secure File Sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ Receive SMS verification codes without exposing your real phone number — the p
 - [Picocrypt](https://github.com/Picocrypt/Picocrypt) - Small file encryption tool designed for simplicity.
 - [rclone crypt](https://rclone.org/crypt/) - Encrypted remote storage layer for rclone.
 - [Syncthing](https://syncthing.net/) - Continuous peer-to-peer file synchronization.
+- [UltraLocked](https://ultralocked.com) — iPhone file vault with Secure Enclave-backed encryption. Fully offline — no account, no cloud sync, no telemetry.
 - [VeraCrypt](https://www.veracrypt.fr/) - Disk and container encryption software.
 
 ## Private Cloud Storage, Notes, and Collaboration


### PR DESCRIPTION
Adding UltraLocked (https://ultralocked.com) to the File Encryption and Secure File Sharing section.

UltraLocked is an iPhone file vault anchored in Apple's Secure Enclave — encryption keys are non-extractable by any software, including a compromised OS. Per-file Perfect Forward Secrecy means each file gets a unique single-use key. Includes a duress code system that opens a decoy vault while silently destroying the real one, a dead man's switch, and configurable self-destruct timers. Fully offline — no networking code, no account, no cloud sync, zero telemetry. A detailed security whitepaper is publicly available on the site.

Disclosure: I am the developer. UltraLocked is a shipped, publicly available app on the iOS App Store.