### PR TITLE
Add TinyTools BG Remover to Photo, Metadata, and Media Privacy

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ Receive SMS verification codes without exposing your real phone number — the p
 - [Immich](https://immich.app/) - Self-hosted photo and video backup solution.
 - [MAT2](https://0xacab.org/jvoisin/mat2) - Metadata anonymization toolkit.
 - [Scrambled Exif](https://gitlab.com/juanitobananas/scrambled-exif) - Android app for removing EXIF metadata before sharing images.
+- [TinyTools BG Remover](https://tinytools-smoky.vercel.app/) - Free in-browser AI background remover that processes images entirely client-side with ONNX/WASM — photos never leave your device, no signup, no upload to any server. Part of [TinyTools](https://tinytools-smoky.vercel.app/), an open-source suite of single-purpose web utilities.
 
 ## Self-Hosted Privacy Tools
 


### PR DESCRIPTION
Hi! Adding **TinyTools BG Remover** — a free, in-browser AI background remover that runs entirely client-side via ONNX/WASM. Images never leave the user's device — no upload, no server, no signup, no account.

- **URL:** https://tinytools-smoky.vercel.app/
- **Category fit:** Photo, Metadata, and Media Privacy — privacy-preserving image processing
- **Privacy properties:** All inference happens locally in the browser; no telemetry; open source

Part of TinyTools, an open-source suite of single-purpose web utilities. Happy to adjust wording or section placement if you'd prefer. Thanks for maintaining this great list!