### PR TITLE
Add TrustYourWebsite: privacy-respecting GDPR/cookie scanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ Receive SMS verification codes without exposing your real phone number — the p
 - [Paperweight](https://www.paperweight.email/) - Mass email unsubscribe, and data deletion tool.
 - [Simple Opt Out](https://simpleoptout.com/) - Directory of opt-out links for data sharing and marketing programs.
 - [Terms of Service; Didn't Read](https://tosdr.org/) - Summaries and ratings for online terms and privacy policies.
+- [TrustYourWebsite](https://trustyourwebsite.com/) - Automated GDPR and cookie compliance scanner for EU and UK small business websites. Free risk score, €2.50 full report, €9.99 premium multi-page scan.
 
 ## Cryptography and Security Libraries
 


### PR DESCRIPTION
Affiliation disclosure: I'm Steven Koppens, the maintainer of TrustYourWebsite. Submitting per this repo's contribution guidelines.

TrustYourWebsite is an automated GDPR and cookie compliance scanner aimed at EU small businesses. It returns a risk score plus an itemised list of compliance issues — cookie classification, CMP detection, third-party tracker inventory, legal page coverage, accessibility-meets-privacy checks via axe-core.

Free tier returns the risk score and issue counts. €9 full report adds the findings, screenshots, and per-issue remediation guidance.

Privacy posture: no tracking on the scanner page, no email gate on the free tier, EU-hosted, scan results never sold or shared. Scanning respects robots.txt with conservative rate limits.

URL: https://trustyourwebsite.com
