### PR TITLE
Add FillSign

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ Receive SMS verification codes without exposing your real phone number — the p
 - [CryptPad](https://cryptpad.org/) - End-to-end encrypted collaborative office suite.
 - [Ente Photos](https://ente.io/) - End-to-end encrypted photo storage and sharing.
 - [Filen](https://filen.io/) - End-to-end encrypted cloud storage.
+- [FillSign](https://fillsign.app) - Fill and sign PDF forms locally in the browser; the file never gets uploaded.
 - [Joplin](https://joplinapp.org/) - Open-source notes app with optional end-to-end encryption.
 - [Nextcloud](https://nextcloud.com/) - Self-hostable file sync and collaboration platform.
 - [Notesnook](https://notesnook.com/) - End-to-end encrypted note-taking app.


### PR DESCRIPTION
This adds **FillSign** (https://fillsign.app) to the **Private Cloud Storage, Notes, and Collaboration** section.

FillSign is a free tool to fill and sign PDF forms entirely in the browser. It runs 100% client-side — the file is never uploaded to a server, and there is no signup required.

The entry uses a neutral tone and is placed in the correct alphabetical position within the section (between "Filen" and "Joplin"), following the list's existing format.