### PR TITLE
Add client-side Password Generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Receive SMS verification codes without exposing your real phone number — the p
 - [Nitrokey](https://www.nitrokey.com/) - Open hardware security keys and encrypted storage devices.
 - [OnlyKey](https://onlykey.io/) - Hardware password manager and security key.
 - [pass](https://www.passwordstore.org/) - Unix password manager using GnuPG and Git.
+- [Password Generator](https://www.nasrtech.dev/tools/password-generator/) - Client-side strong password generator; runs entirely in the browser with no sign-up, upload, or telemetry.
 - [Proton Pass](https://proton.me/pass) - Password manager from Proton.
 - [SoloKeys](https://solokeys.com/) - Open-source FIDO security keys.
 - [YubiKey](https://www.yubico.com/products/) - Hardware security keys for phishing-resistant authentication.


### PR DESCRIPTION
Adds a free, client-side **[Password Generator](https://www.nasrtech.dev/tools/password-generator/)** to the *Password Managers, Passkeys, and Authentication* section (placed alphabetically).

It generates strong passwords entirely in the browser — no sign-up, no upload, no telemetry — which fits the selection criteria (data minimization, user control, no surveillance/telemetry). Free and no affiliate links.

Thanks for curating this list!