### PR TITLE
Add Presend (EXIF Remover + PDF Metadata Remover)

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,8 @@ Receive SMS verification codes without exposing your real phone number — the p
 - [Immich](https://immich.app/) - Self-hosted photo and video backup solution.
 - [MAT2](https://0xacab.org/jvoisin/mat2) - Metadata anonymization toolkit.
 - [Scrambled Exif](https://gitlab.com/juanitobananas/scrambled-exif) - Android app for removing EXIF metadata before sharing images.
+- [Presend EXIF Remover](https://presendapp.netlify.app/tools/exif-remover.html) - Browser-based tool to strip EXIF metadata (GPS, camera model, timestamps) from a photo. Runs entirely client-side, no upload.
+- [Presend PDF Metadata Remover](https://presendapp.netlify.app/tools/pdf-metadata-remover.html) - Removes document info metadata (author, software, dates) from a PDF. Runs entirely client-side, no upload.
 
 ## Self-Hosted Privacy Tools
 


### PR DESCRIPTION
Adds two free, browser-based metadata removal tools — both run entirely client-side, no upload, no account. Fits alongside MAT2/Scrambled Exif in this section.