### PR TITLE
Add Password Generator and TOTP Authenticator to Password Managers, Passkeys, and Authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,8 +166,10 @@ Receive SMS verification codes without exposing your real phone number — the p
 - [Nitrokey](https://www.nitrokey.com/) - Open hardware security keys and encrypted storage devices.
 - [OnlyKey](https://onlykey.io/) - Hardware password manager and security key.
 - [pass](https://www.passwordstore.org/) - Unix password manager using GnuPG and Git.
+- [Password Generator](https://github.com/k-adm/password-generator) - Offline Chrome extension that generates random passwords and diceware passphrases entirely on-device, with no network access.
 - [Proton Pass](https://proton.me/pass) - Password manager from Proton.
 - [SoloKeys](https://solokeys.com/) - Open-source FIDO security keys.
+- [TOTP Authenticator](https://github.com/k-adm/totp-authenticator) - Offline Chrome extension for TOTP, HOTP, and Steam 2FA codes stored locally with optional master-password encryption.
 - [YubiKey](https://www.yubico.com/products/) - Hardware security keys for phishing-resistant authentication.
 
 ## File Encryption and Secure File Sharing


### PR DESCRIPTION
### Additions

Two open-source, fully-offline Chrome (Manifest V3) extensions, added to the **Password Managers, Passkeys, and Authentication** section:

- **Password Generator** - random passwords and diceware passphrases generated on-device; no network access; MIT.
- **TOTP Authenticator** - local TOTP / HOTP / Steam 2FA codes with optional master-password (AES-256-GCM) encryption; no cloud; MIT.

### Checklist

- [x] HTTPS links, no tracking parameters
- [x] Entries added alphabetically within the section
- [x] Descriptions concise, factual, neutral, end with a period
- [x] Open source (MIT), actively maintained

### Disclosure

I am the author of both projects, disclosing affiliation per CONTRIBUTING.md.
