### PR TITLE
Add Get Up to Code (US ADA/CCPA compliance scanner)

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ Receive SMS verification codes without exposing your real phone number — the p
 - [Cover Your Tracks](https://coveryourtracks.eff.org/) - EFF browser tracking and fingerprinting test.
 - [DeleteMe](https://joindeleteme.com/) - Paid service for removing personal data from data broker sites.
 - [DuckDuckGo App Tracking Protection](https://duckduckgo.com/app-tracking-protection) - Android tracker blocking built into DuckDuckGo's browser app.
+- [Get Up to Code](https://getuptocode.com/) - Automated ADA, CCPA and US state privacy compliance scanner for US small business websites. Free risk score, $5 full report, $19 premium multi-page scan.
 - [Have I Been Pwned](https://haveibeenpwned.com/) - Check whether an email address appears in known breaches.
 - [Incogni](https://incogni.com/) - Paid data broker removal service.
 - [JustDeleteMe](https://justdeleteme.xyz/) - Directory of account deletion links and difficulty ratings.


### PR DESCRIPTION
Adds **Get Up to Code** to `## Privacy Checkers, Breach Monitoring, and Data Removal`, placed alphabetically between ExposureCheck and Have I Been Pwned.

```markdown
- [Get Up to Code](https://getuptocode.com/) - Automated ADA, CCPA and US state privacy compliance scanner for US small business websites. Free risk score, $5 full report, $19 premium multi-page scan.
```

**Affiliation disclosure:** I work on this product. Also, it's the same company and scanning engine as [TrustYourWebsite](https://trustyourwebsite.com/), already listed in this section — this is the US-jurisdiction counterpart (ADA/WCAG, CCPA and US state privacy law) rather than a duplicate. Flagging it unprompted since I'd rather you decide than discover it. Happy to close if you prefer one entry per company.

**Against your published criteria:**

- **"Open source is preferred"** — the scanner components are MIT-licensed: https://getuptocode.com/open-source
- **"explains its security model, privacy model, limitations, or trust assumptions"** — https://getuptocode.com/about sets out what the scan does and does not check, and states plainly that it is technical analysis, not legal advice. Findings are written as observations plus conditional exposure context, never as legal conclusions.
- **"actively maintained"** — 25 US guides published in the last month; scanner is in continuous development.
- **"avoids deceptive privacy claims, dark patterns, surveillance advertising"** — no overlay widget, no "makes you compliant" or "ADA certified" claims (a linter blocks that wording in our copy). Worth stating: the site previously carried an inherited "Where we're listed" block naming this list before we were actually in it. That was our error; we removed it from production before opening this PR rather than reword it, and https://getuptocode.com/about now carries no such claim.
- **"No affiliate links. No paid placement."** — neither.

Commit is DCO signed-off.
