### PR TITLE
Add Orden to VPNs, Tor, and Network Privacy

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Receive SMS verification codes without exposing your real phone number — the p
 - [Nym](https://nym.com/) - Mixnet infrastructure for network-level privacy.
 - [OnionShare](https://onionshare.org/) - Share files and host temporary sites through Tor onion services.
 - [Orbot](https://orbot.app/) - Tor proxy for Android.
+- [Orden](https://joinorden.com/) - VPN for censored networks with an open-source Android client on the sing-box core, using VLESS-Reality and Hysteria2 without accounts or logging.
 - [Proton VPN](https://protonvpn.com/) - VPN service from Proton with open-source apps.
 - [Snowflake](https://snowflake.torproject.org/) - Tor pluggable transport that helps people bypass censorship.
 - [Tor Project](https://www.torproject.org/) - Onion-routing network for stronger anonymity.


### PR DESCRIPTION
Adds **Orden** to the VPNs, Tor, and Network Privacy section, alphabetically between Orbot and Proton VPN.

**What it is:** a VPN aimed at heavily censored networks (Russia/Iran-style DPI), with an open-source Android client built on the sing-box core: VLESS + XTLS-Reality and Hysteria2/Salamander, automatic per-node failover, subscription-based (no account), and no telemetry or analytics SDKs in the client. The client also works with self-hosted sing-box/Xray nodes — it parses standard `vless://`, `ss://` and `hysteria2://` share links.

Client source (MIT): https://github.com/tsyrenov1987/orden-android-client

**Disclosure:** I'm the author. This is a paid service, so I understand if it doesn't clear your bar next to Mullvad/IVPN/Proton — feel free to close it, or I'm happy to reword the entry, or narrow it to the open-source client only if you'd prefer that framing.

Checklist:
- [x] Searched the README to avoid duplicates.
- [x] Added to the most relevant section, alphabetically.
- [x] Used the required Markdown format, description ends with a period.
- [x] Link works, no tracking parameters.
- [x] Description is original, not marketing copy.
- [x] Affiliation disclosed above.