### PR TITLE
Add Apstal to Privacy-Friendly Analytics and Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ Receive SMS verification codes without exposing your real phone number — the p
 - [PostHog](https://posthog.com/) - Product analytics suite with self-hosting support.
 - [Swetrix](https://swetrix.com/) - Privacy-focused analytics and monitoring platform.
 - [Umami](https://umami.is/) - Simple, open-source, privacy-focused web analytics.
+- [Apstal](https://apstal.com/) - AI-first web analytics with session replay, adblock-resistant server-side tracking, and a conversational AI assistant.
 
 ## Privacy Checkers, Breach Monitoring, and Data Removal
 


### PR DESCRIPTION
Adds Apstal (https://apstal.com) to the Privacy-Friendly Analytics and Developer Tools section.

Apstal is an AI-first web analytics platform with session replay, adblock-resistant server-side tracking, and a conversational AI assistant. It offers a free forever tier and a Premium plan at $48/month.