### PR TITLE
Add Darkmoon to Cryptography and Security Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ Receive SMS verification codes without exposing your real phone number — the p
 - [Sigstore](https://www.sigstore.dev/) - Signing and transparency tooling for software supply chains.
 - [sops](https://github.com/getsops/sops) - Editor for encrypted secrets files.
 - [The Update Framework](https://theupdateframework.io/) - Framework for securing software update systems.
+- [Darkmoon](https://github.com/ASCIT31/Dark-Moon) - Open source autonomous AI penetration testing platform that runs fully self hosted and local.
 - [TruffleHog](https://github.com/trufflesecurity/trufflehog) - Secret scanning tool for repositories and other sources.
 
 ## Privacy Guides and Learning Tools


### PR DESCRIPTION
Hi, and thanks for maintaining this list.

We would like to suggest adding Darkmoon under Cryptography and Security Libraries. Darkmoon is an open source autonomous AI penetration testing platform, released under the GPLv3 license, covering web, API, Active Directory and Kubernetes. It runs fully self hosted and local, so nothing it discovers ever leaves your own infrastructure, which fits the privacy focus of this list.

We placed it near TruffleHog among the security tooling. Happy to reword or reposition if you prefer.