### PR TITLE
Add Video Size Reducer to Photo, Metadata, and Media Privacy

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ Receive SMS verification codes without exposing your real phone number — the p
 - [Immich](https://immich.app/) - Self-hosted photo and video backup solution.
 - [MAT2](https://0xacab.org/jvoisin/mat2) - Metadata anonymization toolkit.
 - [Scrambled Exif](https://gitlab.com/juanitobananas/scrambled-exif) - Android app for removing EXIF metadata before sharing images.
+- [Video Size Reducer](https://videosizereducer.org/) - Compresses MP4 files to a target size entirely in the browser, so the video is never uploaded to a server.
 
 ## Self-Hosted Privacy Tools
 


### PR DESCRIPTION
Adds **Video Size Reducer** to *Photo, Metadata, and Media Privacy*, placed alphabetically after Scrambled Exif.

- **Link:** https://videosizereducer.org/
- **What it does:** compresses an MP4 to a target file size (10/25/50 MB or a custom limit) or to a quality preset.

**Privacy relevance / trust model:** the transcode runs in the browser through the WebCodecs API. The file is never sent anywhere — there is no upload endpoint and no server-side copy, which is verifiable from the network tab. That is the data-minimisation argument for including it: the usual way to shrink a video for an upload limit is to hand the footage to an online converter, and this removes that step.

Checked against CONTRIBUTING: free, no signup, no affiliate or tracking parameters in the link, description is one factual sentence ending in a period, no hype wording. Closed-source but client-side only, which the Selection Criteria allow when the trust model is clear.
