### PR TITLE
Add Traveler's VPN (BYO-server split-tunnel client)

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Receive SMS verification codes without exposing your real phone number — the p
 - [Proton VPN](https://protonvpn.com/) - VPN service from Proton with open-source apps.
 - [Snowflake](https://snowflake.torproject.org/) - Tor pluggable transport that helps people bypass censorship.
 - [Tor Project](https://www.torproject.org/) - Onion-routing network for stronger anonymity.
+- [Traveler's VPN](https://travelersvpn.com/) - Split-tunnel client for self-hosted Outline, WireGuard, and Trojan servers, built on the open-source sing-box core; no account required.
 - [WireGuard](https://www.wireguard.com/) - Modern VPN protocol and software.
 
 ## DNS, Ad Blocking, and Tracker Blocking


### PR DESCRIPTION
Adds Traveler's VPN to the VPNs section. Per the selection criteria's allowance for closed-source tools where the trust model is clear, here's the case:

- The app is a closed-source client, but the entire tunnel engine is the open-source sing-box core, using standard auditable protocols (Shadowsocks/Outline, WireGuard, Trojan).
- In bring-your-own-server mode the vendor operates no backend at all: you point the app at a server you control, and traffic never touches the vendor's infrastructure, so there is no logging policy to take on faith.
- No account, email, or signup exists; purchases go through the Apple App Store.

Trade-off stated honestly: the client binary itself is not auditable, which is why the entry description names the sing-box core and the self-hosted model. Happy to adjust wording or withdraw if it doesn't meet the bar.

Disclosure: I'm the developer.