### PR TITLE
Add elm.chat to encrypted messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Receive SMS verification codes without exposing your real phone number — the p
 ## Encrypted Messaging and Secure Chat
 
 - [Briar](https://briarproject.org/) - Peer-to-peer messaging designed for censorship resistance and offline scenarios.
+- [elm.chat](https://elm.chat/) - Open-source, account-free disposable chat rooms with browser-side encryption, single-use invites, and no persisted server-side transcript.
 - [Element](https://element.io/) - Matrix client for end-to-end encrypted personal and team chat.
 - [Jami](https://jami.net/) - Peer-to-peer voice, video, and messaging app.
 - [Matrix](https://matrix.org/) - Open protocol for decentralized, end-to-end encrypted communication.


### PR DESCRIPTION
Adds elm.chat to **Encrypted Messaging and Secure Chat** using the required neutral, single-sentence format and alphabetical placement.

Why it fits the published criteria:
- AGPL-3.0 source: https://github.com/shawnbure/elm-chat
- working public site: https://elm.chat
- public threat model and limitations: https://github.com/shawnbure/elm-chat/blob/main/docs/threat-model.md
- no third-party tracking scripts or advertising; aggregate counters contain only fixed event/source labels
- browser-side encryption, account-free use, single-use invites, and no persisted server-side transcript

Security disclosure: the project has not completed an independent audit. Its relay can observe ordinary metadata such as IP addresses, timing, sizes, and presence; message authentication is not complete; endpoints and recipients can retain content.

Affiliation disclosure: I created and maintain elm.chat.