### PR TITLE
Add Metadata Remover to photo and metadata privacy

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ Receive SMS verification codes without exposing your real phone number — the p
 - [ImageOptim](https://imageoptim.com/mac) - Image optimizer for macOS that can remove metadata.
 - [Immich](https://immich.app/) - Self-hosted photo and video backup solution.
 - [MAT2](https://0xacab.org/jvoisin/mat2) - Metadata anonymization toolkit.
+- [Metadata Remover](https://metadataremover.ai/) - Inspect and remove image metadata locally without uploads or signup.
 - [Scrambled Exif](https://gitlab.com/juanitobananas/scrambled-exif) - Android app for removing EXIF metadata before sharing images.
 
 ## Self-Hosted Privacy Tools


### PR DESCRIPTION
Adds [Metadata Remover](https://metadataremover.ai/) to Photo, Metadata, and Media Privacy. It inspects and removes image metadata locally in the browser without signup. I maintain Metadata Remover.