### PR TITLE
Add ImgSplit to Photo, Metadata, and Media Privacy

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ Receive SMS verification codes without exposing your real phone number — the p
 - [ExifEraser](https://github.com/Tommy-Geenexus/exif-eraser) - Android app for removing image metadata.
 - [ExifTool](https://exiftool.org/) - Read, write, and remove metadata from media files.
 - [ImageOptim](https://imageoptim.com/mac) - Image optimizer for macOS that can remove metadata.
+- [ImgSplit](https://imgsplit.com/) - In-browser image toolkit for splitting, compressing, watermarking, and local background removal without uploading files.
 - [Immich](https://immich.app/) - Self-hosted photo and video backup solution.
 - [MAT2](https://0xacab.org/jvoisin/mat2) - Metadata anonymization toolkit.
 - [Scrambled Exif](https://gitlab.com/juanitobananas/scrambled-exif) - Android app for removing EXIF metadata before sharing images.


### PR DESCRIPTION
Adds [ImgSplit](https://imgsplit.com/) to **Photo, Metadata, and Media Privacy**.

ImgSplit is a free, MIT-licensed, in-browser image toolkit (grid/carousel split, compression, watermarks, local background removal). Images are processed in the browser and are not uploaded.

Disclosure: I maintain this project ([ZooHero500/imgsplit](https://github.com/ZooHero500/imgsplit)). Not affiliated with splitimg.com or @imgsplit/core.

Entry is alphabetical in the section.