### PR TITLE
Add PDF Metadata Remover to Photo, Metadata, and Media Privacy

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ Receive SMS verification codes without exposing your real phone number — the p
 - [ImageOptim](https://imageoptim.com/mac) - Image optimizer for macOS that can remove metadata.
 - [Immich](https://immich.app/) - Self-hosted photo and video backup solution.
 - [MAT2](https://0xacab.org/jvoisin/mat2) - Metadata anonymization toolkit.
+- [PDF Metadata Remover](https://intabtools.com/pdf/pdf-metadata-remover) - Removes author, producer, and XMP metadata from PDF files by rewriting the document in the browser; the file never leaves the tab.
 - [Scrambled Exif](https://gitlab.com/juanitobananas/scrambled-exif) - Android app for removing EXIF metadata before sharing images.
 
 ## Self-Hosted Privacy Tools


### PR DESCRIPTION
## What
Adds [PDF Metadata Remover](https://intabtools.com/pdf/pdf-metadata-remover), part of [In-Tab Tools](https://intabtools.com), to the Photo, Metadata, and Media Privacy section.

The page rewrites a PDF's object graph in the browser to strip Info-dictionary fields (author, producer, etc.), XMP metadata blocks, and comment authorship. The file is never uploaded; it stays in the browser tab the whole time.

**Disclosure:** I maintain In-Tab Tools.

## Checklist
- [x] Searched the README to avoid duplicates (no existing PDF-specific browser metadata tool in this list)
- [x] Added the entry to the most relevant section
- [x] Used the required Markdown format
- [x] Link works and contains no tracking parameters
- [x] Description is original, factual, neutral, and not copied from marketing copy
- [x] Disclosed affiliation with the project