### PR TITLE
Add Plainsay

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ Receive SMS verification codes without exposing your real phone number — the p
 - [Joplin](https://joplinapp.org/) - Open-source notes app with optional end-to-end encryption.
 - [Nextcloud](https://nextcloud.com/) - Self-hostable file sync and collaboration platform.
 - [Notesnook](https://notesnook.com/) - End-to-end encrypted note-taking app.
+- [Plainsay](https://plainsay.app/) - Dictation for macOS that transcribes speech on the device, so voice recordings are not sent to a server.
 - [Proton Drive](https://proton.me/drive) - Encrypted cloud storage from Proton.
 - [qnote](https://github.com/Omibranch/qnote) - Minimal frameless notepad with local-only storage, no telemetry, no cloud. Markdown live preview, real PDF export via Typst, OCR via Tesseract, automatic version history. Available on AUR.
 - [Standard Notes](https://standardnotes.com/) - Encrypted notes app with cross-platform sync.


### PR DESCRIPTION
Adds [Plainsay](https://plainsay.app/) — MIT-licensed dictation for macOS that transcribes on the device.

## Why it belongs on a privacy list

Dictation is an unusually sensitive input: passwords read aloud, medical notes, other people's names. The mainstream options upload the recording. Wispr Flow states plainly that transcription always happens in the cloud; Apple's own dictation sends audio to Apple for anything beyond short phrases.

Plainsay runs speech recognition on the Mac through Core ML (WhisperKit or NVIDIA Parakeet). Once the model is downloaded, dictation needs no account and no network. Optional cloud transcription and cleanup exist, and the site states exactly what each one sends rather than calling the whole app "100% offline".

Against your selection criteria: open source (MIT, client is public), maintained (released this week), no telemetry from the Mac client, and no deceptive claims — the [privacy page](https://plainsay.app/why-on-device/) enumerates each network path, including the ones that do send data.

## On the category — please move it if you disagree

I put it under **Private Cloud Storage, Notes, and Collaboration**, next to qnote, because that is where the local-first, no-telemetry productivity tools live. It is the closest fit rather than an exact one: Plainsay is an input method, not a notes app. If you would rather it sat elsewhere, or you would rather not carry a dictation entry at all, I am happy either way — please just say so rather than spending time on it.

Format follows CONTRIBUTING.md: one sentence, factual, neutral, ends with a period, inserted alphabetically.