### PR TITLE
Add Presend to Photo, Metadata, and Media Privacy

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ Receive SMS verification codes without exposing your real phone number — the p
 - [Mozilla Monitor](https://monitor.mozilla.org/) - Breach alerts and exposure guidance from Mozilla.
 - [Simple Opt Out](https://simpleoptout.com/) - Directory of opt-out links for data sharing and marketing programs.
 - [Terms of Service; Didn't Read](https://tosdr.org/) - Summaries and ratings for online terms and privacy policies.
+- [Paperweight] - Scans your inbox to map your digital footprint, then helps you take back control and delete your data.
 
 ## Cryptography and Security Libraries
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ No affiliate links. No paid placement. No fake “best” rankings.
 - [Mailvelope](https://mailvelope.com/) - Browser extension for OpenPGP email encryption.
 - [Proton Mail](https://proton.me/mail) - Encrypted email service with web, desktop, and mobile apps.
 - [SimpleLogin](https://simplelogin.io/) - Open-source email alias service for shielding your real email address.
+- [Thexyz](https://www.thexyz.com) - Email hosting service with custom domains, spam filtering, and privacy-focused mailbox management.
 - [Tuta](https://tuta.com/) - Encrypted email, calendar, and contacts service.
 
 ## Encrypted Messaging and Secure Chat

--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ Receive SMS verification codes without exposing your real phone number — the p
 - [Nextcloud](https://nextcloud.com/) - Self-hostable file sync and collaboration platform.
 - [Notesnook](https://notesnook.com/) - End-to-end encrypted note-taking app.
 - [Proton Drive](https://proton.me/drive) - Encrypted cloud storage from Proton.
+- [qnote](https://github.com/Omibranch/qnote) - Minimal frameless notepad with local-only storage, no telemetry, no cloud. Markdown live preview, real PDF export via Typst, OCR via Tesseract, automatic version history. Available on AUR.
 - [Standard Notes](https://standardnotes.com/) - Encrypted notes app with cross-platform sync.
 - [Tresorit](https://tresorit.com/) - End-to-end encrypted cloud storage and collaboration.
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ No affiliate links. No paid placement. No fake “best” rankings.
 
 - [anon.li Alias](https://anon.li/alias) - Private email aliases with forwarding, reply-by-alias, PGP forwarding, and custom domains.
 - [addy.io](https://addy.io/) - Open-source anonymous email forwarding and aliasing.
+- [Aster Mail](https://astermail.org/) - Zero-access encrypted email with anonymous aliases and custom domain support.
 - [DuckDuckGo Email Protection](https://duckduckgo.com/email/) - Email forwarding service that removes common trackers.
 - [Firefox Relay](https://relay.firefox.com/) - Email masks from Mozilla for hiding your real address.
 - [Forward Email](https://forwardemail.net/) - Open-source email forwarding service with custom domain support.

--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ Receive SMS verification codes without exposing your real phone number — the p
 - [Paperweight](https://www.paperweight.email/) - Mass email unsubscribe, and data deletion tool.
 - [Simple Opt Out](https://simpleoptout.com/) - Directory of opt-out links for data sharing and marketing programs.
 - [Terms of Service; Didn't Read](https://tosdr.org/) - Summaries and ratings for online terms and privacy policies.
+- [TrustYourWebsite](https://trustyourwebsite.com/) - Automated GDPR and cookie compliance scanner for EU and UK small business websites. Free risk score, €2.50 full report, €9.99 premium multi-page scan.
 
 ## Cryptography and Security Libraries
 

--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ Receive SMS verification codes without exposing your real phone number — the p
 - [ImageOptim](https://imageoptim.com/mac) - Image optimizer for macOS that can remove metadata.
 - [Immich](https://immich.app/) - Self-hosted photo and video backup solution.
 - [MAT2](https://0xacab.org/jvoisin/mat2) - Metadata anonymization toolkit.
+- [Presend](https://presend.pages.dev/tools/exif-remover) - Browser-based tool to strip EXIF metadata (GPS, camera model, timestamps) from a photo before sharing it.
 - [Scrambled Exif](https://gitlab.com/juanitobananas/scrambled-exif) - Android app for removing EXIF metadata before sharing images.
 
 ## Self-Hosted Privacy Tools

--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ Receive SMS verification codes without exposing your real phone number — the p
 - [Cover Your Tracks](https://coveryourtracks.eff.org/) - EFF browser tracking and fingerprinting test.
 - [DeleteMe](https://joindeleteme.com/) - Paid service for removing personal data from data broker sites.
 - [DuckDuckGo App Tracking Protection](https://duckduckgo.com/app-tracking-protection) - Android tracker blocking built into DuckDuckGo's browser app.
+- [ExposureCheck](https://github.com/coraaegis/exposurecheck) - Local-first CLI that audits your own Reddit/X export for AI re-identification (mosaic) risk and shows what to generalise or remove. No dossier, no telemetry, bring your own model.
 - [Have I Been Pwned](https://haveibeenpwned.com/) - Check whether an email address appears in known breaches.
 - [Incogni](https://incogni.com/) - Paid data broker removal service.
 - [JustDeleteMe](https://justdeleteme.xyz/) - Directory of account deletion links and difficulty ratings.
@@ -267,6 +268,7 @@ Receive SMS verification codes without exposing your real phone number — the p
 - [Simple Opt Out](https://simpleoptout.com/) - Directory of opt-out links for data sharing and marketing programs.
 - [Terms of Service; Didn't Read](https://tosdr.org/) - Summaries and ratings for online terms and privacy policies.
 - [TrustYourWebsite](https://trustyourwebsite.com/) - Automated GDPR and cookie compliance scanner for EU and UK small business websites. Free risk score, €2.50 full report, €9.99 premium multi-page scan.
+
 
 ## Cryptography and Security Libraries
 

--- a/README.md
+++ b/README.md
@@ -261,9 +261,9 @@ Receive SMS verification codes without exposing your real phone number — the p
 - [Incogni](https://incogni.com/) - Paid data broker removal service.
 - [JustDeleteMe](https://justdeleteme.xyz/) - Directory of account deletion links and difficulty ratings.
 - [Mozilla Monitor](https://monitor.mozilla.org/) - Breach alerts and exposure guidance from Mozilla.
+- [Paperweight](https://www.paperweight.email/) - Mass email unsubscribe, and data deletion tool.
 - [Simple Opt Out](https://simpleoptout.com/) - Directory of opt-out links for data sharing and marketing programs.
 - [Terms of Service; Didn't Read](https://tosdr.org/) - Summaries and ratings for online terms and privacy policies.
-- [Paperweight] - Scans your inbox to map your digital footprint, then helps you take back control and delete your data.
 
 ## Cryptography and Security Libraries
 


### PR DESCRIPTION
Disclosure: I maintain this project.

Adds Presend's EXIF remover, alongside ExifTool/MAT2/Scrambled Exif. Browser-based (no install needed, unlike the others in this section), runs entirely client-side — the image never leaves the device.

https://presend.pages.dev/tools/exif-remover