### PR TITLE
Add Noctis to VPNs, Tor, and Network Privacy

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Receive SMS verification codes without exposing your real phone number — the p
 - [IVPN](https://www.ivpn.net/) - VPN provider with privacy-oriented policies and clients.
 - [Lokinet](https://lokinet.org/) - Onion-routed network for private browsing and service access.
 - [Mullvad VPN](https://mullvad.net/) - Privacy-focused VPN with anonymous account numbers and cash payment support.
+- [Noctis](https://noctis.c0nn3ct.info/) - Chrome extension that routes browser traffic through your own VLESS, Trojan, Shadowsocks, Hysteria2, TUIC, or WireGuard servers and leaves the rest of the system unproxied.
 - [Nym](https://nym.com/) - Mixnet infrastructure for network-level privacy.
 - [OnionShare](https://onionshare.org/) - Share files and host temporary sites through Tor onion services.
 - [Orbot](https://orbot.app/) - Tor proxy for Android.


### PR DESCRIPTION
Noctis is a Chrome extension that sends browser traffic to a proxy server the user runs. A native helper starts a pinned sing-box, Xray, or mihomo binary and points Chrome at its local SOCKS listener, so the rest of the machine keeps its normal route. Protocols: VLESS, VMess, Trojan, Shadowsocks, Hysteria2, TUIC, AnyTLS, WireGuard, SOCKS, HTTP.

- Site: https://noctis.c0nn3ct.info/
- Chrome Web Store: https://chromewebstore.google.com/detail/noctis/nmhobajopepdpihahepaddpdifdcenpn
- Privacy policy: https://noctis.c0nn3ct.info/privacy/

On the trust model, since the list weighs it: the extension ships closed source under a EULA, and the native helper is MIT with public source at https://github.com/c0nn3ct-info/noctis. There is no account, no analytics SDK, no crash reporter, and no remote configuration endpoint. The project runs no servers of its own, so the only traffic is what the user's own proxy carries, plus an optional IP check that rides that same proxy.

Checklist:

- [x] Searched the README for duplicates
- [x] Added to VPNs, Tor, and Network Privacy, alphabetically between Mullvad and Nym
- [x] Used the required Markdown format
- [x] Link resolves and carries no tracking parameters
- [x] Description written for this PR, not vendor copy
- [x] Disclosure: I maintain this project
