### PR TITLE
Add VaultKeepR to Password Managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ Receive SMS verification codes without exposing your real phone number — the p
 - [pass](https://www.passwordstore.org/) - Unix password manager using GnuPG and Git.
 - [Proton Pass](https://proton.me/pass) - Password manager from Proton.
 - [SoloKeys](https://solokeys.com/) - Open-source FIDO security keys.
+- [VaultKeepR](https://vaultkeepr.xyz/) - Zero-knowledge password manager with no email or account; client-side encryption and IPFS vault sync.
 - [YubiKey](https://www.yubico.com/products/) - Hardware security keys for phishing-resistant authentication.
 
 ## File Encryption and Secure File Sharing


### PR DESCRIPTION
Adds VaultKeepR to the Password Managers section (alphabetical order). Different trust model from the entries listed: no email or account is required (identity is an on-chain smart account), credentials and metadata are encrypted client-side, and the vault syncs as encrypted blobs over IPFS. Open source: https://github.com/VaultKeepR/vaultkeepr-public